### PR TITLE
Mantener filtro activo al modificar tareas

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,3 +1,5 @@
+let currentFilter = 'all';
+
 document.addEventListener('DOMContentLoaded', () => {
     const taskInput = document.getElementById('taskInput');
     const addTaskBtn = document.getElementById('addTask');
@@ -49,7 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
         };
         tasks.push(task);
         saveTasks();
-        renderTasks();
+        renderTasks(currentFilter);
         taskInput.value = '';
     }
 
@@ -59,7 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (task) {
             task.status = !task.status;
             saveTasks();
-            renderTasks();
+            renderTasks(currentFilter);
         }
     }
 
@@ -67,7 +69,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function deleteTask(id) {
         tasks = tasks.filter(task => task.id !== id);
         saveTasks();
-        renderTasks();
+        renderTasks(currentFilter);
     }
 
     // Función para guardar las tareas en localStorage
@@ -96,10 +98,11 @@ document.addEventListener('DOMContentLoaded', () => {
         btn.addEventListener('click', () => {
             filterBtns.forEach(b => b.classList.remove('active'));
             btn.classList.add('active');
-            renderTasks(btn.dataset.filter);
+            currentFilter = btn.dataset.filter;
+            renderTasks(currentFilter);
         });
     });
 
     // Inicializar la aplicación
-    renderTasks();
+    renderTasks(currentFilter);
 });


### PR DESCRIPTION
## Summary
- introduce global `currentFilter`
- render tasks with the active filter when adding, toggling or deleting
- update active filter on button click and reuse it

## Testing
- `node test.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6844bcc9bac083338fea81cf5b9fab5b